### PR TITLE
Move pkgeval badge to the developers documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Examples](https://img.shields.io/badge/examples-RxInfer-brightgreen)](https://biaslab.github.io/RxInfer.jl/stable/examples/overview/)
 [![Build Status](https://github.com/biaslab/RxInfer.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/biaslab/RxInfer.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/biaslab/RxInfer.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/biaslab/RxInfer.jl)
-[![PkgEval](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/R/RxInfer.svg)](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/report.html)
 [![DOI](https://img.shields.io/badge/Journal%20of%20Open%20Source%20Software-10.21105/joss.05161-critical)](https://doi.org/10.21105/joss.05161)
 [![Zenodo](https://img.shields.io/badge/Zenodo-10.5281/zenodo.7774921-important)](https://zenodo.org/badge/latestdoi/501995296)
 

--- a/docs/src/contributing/overview.md
+++ b/docs/src/contributing/overview.md
@@ -6,6 +6,13 @@ We welcome all possible contributors. This page details some of the guidelines t
 
 We track bugs using [GitHub issues](https://github.com/biaslab/RxInfer.jl/issues). We encourage you to write complete, specific, reproducible bug reports. Mention the versions of Julia and `RxInfer` for which you observe unexpected behavior. Please provide a concise description of the problem and complement it with code snippets, test cases, screenshots, tracebacks or any other information that you consider relevant. This will help us to replicate the problem and narrow the search space for solutions.
 
+### Nightly Julia status
+
+The badge that indicates if `RxInfer` can be installed on a Julia nightly version. The failing badge may indicate either a problem with `RxInfer` itself of with one if the dependencies. 
+Click on the badge to get the latest evaluation report.
+
+[![PkgEval](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/R/RxInfer.svg)](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/report.html)
+
 ## Suggesting features
 
 We welcome new feature proposals. However, before submitting a feature request, consider a few things:


### PR DESCRIPTION
I moved the PkgEval badge from README to the developers documentation. The badge does only confuse users, the failing badge does not indicate that there is a problem with RxInfer, but can also indicate a problem with some of its dependencies (which, in 99% if cases, it is a problem with the dependencies). 