### PR TITLE
Update constraints macro documentation

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 GraphPPL = "b3f8163a-e979-4e85-b43e-1f63d8c8b42c"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,11 +1,13 @@
 using RxInfer
 using Documenter
+using DocumenterCitations
 
 ## https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988
 ## https://gr-framework.org/workstations.html#no-output
 ENV["GKSwstype"] = "100"
 
 DocMeta.setdocmeta!(RxInfer, :DocTestSetup, :(using RxInfer); recursive = true)
+bib = CitationBibliography(joinpath(@__DIR__, "src", "references.bib"))
 
 # This must be auto-generated with `make examples`
 ExamplesPath = joinpath(@__DIR__, "src", "examples")
@@ -131,7 +133,8 @@ makedocs(;
         ],
         "Contributing" =>
             ["Overview" => "contributing/overview.md", "Adding a new example" => "contributing/new-example.md", "Publishing a new release" => "contributing/new-release.md"]
-    ]
+    ],
+    plugins=[bib]
 )
 
 deploydocs(; repo = "github.com/biaslab/RxInfer.jl", devbranch = "main")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,7 @@ using DocumenterCitations
 ENV["GKSwstype"] = "100"
 
 DocMeta.setdocmeta!(RxInfer, :DocTestSetup, :(using RxInfer); recursive = true)
-bib = CitationBibliography(joinpath(@__DIR__, "src", "references.bib"))
+bib = CitationBibliography(joinpath(@__DIR__, "src", "references.bib"); style=:authoryear)
 
 # This must be auto-generated with `make examples`
 ExamplesPath = joinpath(@__DIR__, "src", "examples")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -103,3 +103,6 @@ The `RxInfer` unites 3 core packages into one powerful reactive message passing-
 
 ```@index
 ```
+## Bibliography
+```@bibliography
+```

--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -1,0 +1,10 @@
+@article{csenoz2021variational,
+  title={Variational message passing and local constraint manipulation in factor graphs},
+  author={Senoz, Ismail and van de Laar, Thijs and Bagaev, Dmitry and de Vries, Bert},
+  journal={Entropy},
+  volume={23},
+  number={7},
+  pages={807},
+  year={2021},
+  publisher={MDPI}
+}


### PR DESCRIPTION
This is a first version for a rewrite of the constraints macro documentation. There's a couple of things that should happen before we merge this:

- [ ] Release `RxInfer` 3.0, half of the code in this example is written for the next `GraphPPL` version
- [ ] Decide whether to use `DocumenterCitations`. I kinda like the $\LaTeX{}$-like referencing, but it might be difficult to change this everywhere. 
- [ ] Change the link for the BFE explanation to the actual page (when it exists)
- [ ] Change all `julia` tagged code blocks to `@example manual_constraints`
- [ ] Change all `RxInfer` 2.0 code to 3.0 code.

The explanation is on the short side now, I feel. Let's discuss on which topics we want to elaborate further and which we want to leave as short as they are now