### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,8 +3,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [review_requested,reopened,synchronize]
-  pull_request_review:
-    types: [submitted,edited]
   push:
     branches:
       - 'main'


### PR DESCRIPTION
This PR removes the `pull_request_review` event trigger for GitHub Actions as it generates to much unnecessary CI builds (on each review comment).